### PR TITLE
interpret SampleAfterValue as decimal value

### DIFF
--- a/src/BETA/Generate-PmuRegFile.ps1
+++ b/src/BETA/Generate-PmuRegFile.ps1
@@ -331,7 +331,7 @@ foreach ($pmuConfig in $pmuConfigArray) {
 
         $eventCode = [convert]::ToInt32($eventCodes[0], 16)
         $unit = [convert]::ToInt32($pmuConfig.UMask, 16)
-        $interval = [convert]::ToInt32($pmuConfig.SampleAfterValue, 16)
+        $interval = [convert]::ToInt32($pmuConfig.SampleAfterValue, 10)
         "[$pmuRegKeyRoot\$pmuGroupName\$pmuSourceName]" >> $regKeyPath
         "`"Event`"=dword:{0:X8}" -f $eventCode >> $regKeyPath
         "`"Unit`"=dword:{0:X8}" -f $unit >> $regKeyPath


### PR DESCRIPTION
Changes .reg from:

```
[HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\WMI\ProfileSource\alderlake_goldencove_core\BR_INST_RETIRED.ALL_BRANCHES]
"Event"=dword:000000C4
"Unit"=dword:00000000
"Interval"=dword:00400009
```

to

```
[HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\WMI\ProfileSource\alderlake_goldencove_core\BR_INST_RETIRED.ALL_BRANCHES]
"Event"=dword:000000C4
"Unit"=dword:00000000
"Interval"=dword:00061A89
```

Given this source:

```json
{
      "EventCode": "0xc4",
      "UMask": "0x00",
      "EventName": "BR_INST_RETIRED.ALL_BRANCHES",
      "BriefDescription": "All branch instructions retired.",
      "PublicDescription": "Counts all branch instructions retired.",
      "Counter": "0,1,2,3,4,5,6,7",
      "PEBScounters": "0,1,2,3,4,5,6,7",
      "SampleAfterValue": "400009",
      "MSRIndex": "0x00",
      "MSRValue": "0x00",
      "Precise": "1",
      "CollectPEBSRecord": "2",
      "TakenAlone": "0",
      "CounterMask": "0",
      "Invert": "0",
      "EdgeDetect": "0",
      "Data_LA": "0",
      "L1_Hit_Indication": "0",
      "Errata": "null",
      "Offcore": "0",
      "Deprecated": "0",
      "PDISTCounter": "0",
      "Speculative": "0"
    }
```