### PR TITLE
Better Heuristics for choosing NonPagedMemory in Custom WPR Profiles

### DIFF
--- a/src/WPRP/Defender.15002.wprp
+++ b/src/WPRP/Defender.15002.wprp
@@ -164,7 +164,7 @@
     <!-- Code Integrity -->
 
     <!-- Microsoft-Windows-CodeIntegrity : In-Process via CI.dll -->
-    <EventProvider Id="EP_CodeIntegrity" Name="4ee76bd8-3cf4-44a0-a0ac-3937643e37a3" Stack="true">
+    <EventProvider Id="EP_CodeIntegrity" Name="4ee76bd8-3cf4-44a0-a0ac-3937643e37a3" NonPagedMemory="true" Stack="true">
       <!-- Requires WPR v10.15002+ -->
       <EventFilters FilterIn="true">
         <EventId Value="3007" /> <!-- PageHashFoundInImageCertificate -->

--- a/src/WPRP/Defender.wprp
+++ b/src/WPRP/Defender.wprp
@@ -132,10 +132,10 @@
     <!-- Code Integrity -->
 
     <!-- Microsoft-Windows-CodeIntegrity : In-Process via CI.dll -->
-    <EventProvider Id="EP_CodeIntegrity" Name="4ee76bd8-3cf4-44a0-a0ac-3937643e37a3" Stack="true" />
+    <EventProvider Id="EP_CodeIntegrity" Name="4ee76bd8-3cf4-44a0-a0ac-3937643e37a3" NonPagedMemory="true" Stack="true" />
 
     <!-- Microsoft-Windows-CodeIntegrity : In-Process via CI.dll -->
-    <EventProvider Id="EP_CodeIntegrity_Regions" Name="4ee76bd8-3cf4-44a0-a0ac-3937643e37a3" Level="5" />
+    <EventProvider Id="EP_CodeIntegrity_Regions" Name="4ee76bd8-3cf4-44a0-a0ac-3937643e37a3" NonPagedMemory="true" Level="5" />
 
     <!-- Microsoft.Windows.Security.CodeIntegrity.NWActivity : In-Proc -->
     <EventProvider Id="EP_NWActivity"    Name="28dcc28b-3e31-527b-efd6-b4cc4d73d158" />


### PR DESCRIPTION
It is important, in the crafted WPR Profiles and the generated WPRPs, to carefully choose when to use the attribute: `NonPagedMemory="true"`
Generally it's used when tracing kernel drivers, particularly the WIN32K provider, because you don't want to create a paging interrupt at that level.
See: [WPR Attributes](https://devblogs.microsoft.com/performance-diagnostics/authoring-custom-profile-part3/#:~:text=NonPagedMemory) and [For Kernel Mode Providers](https://learn.microsoft.com/en-us/windows-hardware/drivers/devtest/capture-and-view-tracelogging-data#:~:text=NonPagedMemory)
This change adds NonPagedMemory="true" to the CodeIntegrity provider (which runs in kernel mode).
It also adds stronger heuristics to the code which interprets the WPT_XPERF environment variable and creates a custom WPRP.
It does this by looking up the (manifested) provider in the registry by name or by guid. Then it checks whether the resource module ends with .sys, etc.
See UseNonPagedMemory and GetETWManifestRegistryKey.