### PR TITLE
Trace shutdown

### DIFF
--- a/src/INCLUDE.WPA.ps1
+++ b/src/INCLUDE.WPA.ps1
@@ -397,6 +397,7 @@ Param (
 	if (!$XPerfPath)
 	{
 		Write-Status "Not downloading symbols in the background. Did not find: XPerf.exe"
+		Write-Status 'Install the Windows Performance Toolkit from: https://aka.ms/adk'
 		return $False
 	}
 
@@ -437,7 +438,7 @@ Param (
 	$ErrResult = $True
 	[DateTime]$PreStartTime = Get-Date
 
-	# Launch the viewer without Admin privileges, if possible.
+	# Launch XPerf without Admin privileges, if possible.
 
 	if ((CheckAdminPrivilege) -and (CheckFileUserPrivilege $XPerfPath $ETL))
 	{
@@ -644,8 +645,7 @@ Param (
 			$fResolving = BackgroundResolveSymbols $TraceFilePath
 			if ($fResolving) { Write-Warn "Referenced symbols are being downloaded in the background." }
 
-			Write-Warn "https://github.com/microsoft/MSO-Scripts/wiki/Advanced-Symbols#optimize:~:text=FastSym"
-
+			Write-Warn "https://github.com/microsoft/MSO-Scripts/wiki/Advanced-Symbols#fastsym"
 		}
 	}
 

--- a/src/WPRP/WindowsProviders.15002.wprp
+++ b/src/WPRP/WindowsProviders.15002.wprp
@@ -257,7 +257,39 @@
 
     <EventProvider Id="EP_Microsoft-Windows-Subsys-SMSS" Name="43e63da5-41d1-4fbf-aded-1bbed98fdd1d" Level="4" /> <!-- Microsoft-Windows-Subsys-SMSS -->
 
-    <EventProvider Id="EP_Microsoft-Windows-Winlogon" Name="dbe9b383-7cf3-4331-91cc-a3cb16a3b538" Level="4" /> <!-- Microsoft-Windows-Winlogon -->
+    <EventProvider Id="EP_Microsoft-Windows-Subsys-Csr" Name="e8316a2d-0d94-4f52-85dd-1e15b66c5891" Level="4" /> <!-- Microsoft-Windows-Subsys-Csr -->
+
+    <EventProvider Id="EP_Microsoft-Windows-Services" Name="0063715b-eeda-4007-9429-ad526f62696e" Level="4"> <!-- Microsoft-Windows-Services -->
+      <Keywords>
+        <Keyword Value="0x00010000" />
+      </Keywords>
+    </EventProvider>
+
+    <EventProvider Id="EP_Microsoft-Windows-Winsrv" Name="9d55b53d-449b-4824-a637-24f9d69aa02f" Level="4"> <!-- Microsoft-Windows-Winsrv -->
+      <Keywords>
+        <Keyword Value="0x00000100" />
+      </Keywords>
+    </EventProvider>
+
+    <EventProvider Id="EP_Microsoft-Windows-Wininit" Name="206f6dea-d3c5-4d10-bc72-989f03c8b84b" Level="4"> <!-- Microsoft-Windows-Wininit -->
+      <Keywords>
+        <Keyword Value="0x00010000" />
+      </Keywords>
+    </EventProvider>
+
+    <EventProvider Id="EP_Microsoft-Windows-Winlogon" Name="dbe9b383-7cf3-4331-91cc-a3cb16a3b538" Level="4"> <!-- Microsoft-Windows-Winlogon -->
+      <Keywords>
+        <Keyword Value="0x00030000" />
+      </Keywords>
+    </EventProvider>
+
+    <EventProvider Id="EP_Microsoft-Windows-Kernel-Power" Name="331c3b3a-2005-44c2-ac5e-77220c37d6b4" Level="4"> <!-- Microsoft-Windows-Kernel-Power -->
+      <Keywords>
+        <Keyword Value="0x00000008" />
+      </Keywords>
+    </EventProvider>
+
+    <EventProvider Id="EP_Microsoft-Windows-Shell-AuthUI" Name="63d2bb1d-e39a-41b8-9a3d-52dd06677588" Level="4" /> <!-- Microsoft-Windows-Shell-AuthUI -->
 
 <!--
     Profile Declarations
@@ -339,6 +371,35 @@
 
     <Profile Name="WindowsStart" Description="Standalone Windows Providers for OS Startup"
      DetailLevel="Light" LoggingMode="Memory" Base="WindowsStart.Light.File" Id="WindowsStart.Light.Memory" />
+
+    <!-- Windows Shut-down (may stand alone) -->
+
+    <Profile Name="WindowsShutdown" Description="Standalone Windows Providers for OS Shutdown"
+     DetailLevel="Light" LoggingMode="File" Base="Basic.Light.File" Id="WindowsShutdown.Light.File">
+      <Collectors Operation="Add">
+
+        <!-- Stand-alone profile: bare minimum -->
+        <SystemCollectorId Value="SC_4-MB">
+          <SystemProviderId Value="SP_Base" />
+        </SystemCollectorId>
+
+        <EventCollectorId Value="EC_16-MB">
+          <EventProviders Operation="Add">
+            <EventProviderId Value="EP_Microsoft-Windows-Wininit" />
+            <EventProviderId Value="EP_Microsoft-Windows-Winlogon" />
+            <EventProviderId Value="EP_Microsoft-Windows-Services" />
+            <EventProviderId Value="EP_Microsoft-Windows-Winsrv" />
+            <EventProviderId Value="EP_Microsoft-Windows-Subsys-Csr" />
+            <EventProviderId Value="EP_Microsoft-Windows-Kernel-Power" />
+            <EventProviderId Value="EP_Microsoft-Windows-Shell-AuthUI" />
+          </EventProviders>
+        </EventCollectorId>
+
+      </Collectors>
+    </Profile>
+
+    <Profile Name="WindowsShutdown" Description="Standalone Windows Providers for OS Shutdown"
+     DetailLevel="Light" LoggingMode="Memory" Base="WindowsShutdown.Light.File" Id="WindowsShutdown.Light.Memory" />
 
     <!-- Tutti Frutti (may stand-alone) -->
 

--- a/src/WPRP/WindowsProviders.wprp
+++ b/src/WPRP/WindowsProviders.wprp
@@ -258,7 +258,39 @@
 
     <EventProvider Id="EP_Microsoft-Windows-Subsys-SMSS" Name="43e63da5-41d1-4fbf-aded-1bbed98fdd1d" Level="4" /> <!-- Microsoft-Windows-Subsys-SMSS -->
 
-    <EventProvider Id="EP_Microsoft-Windows-Winlogon" Name="dbe9b383-7cf3-4331-91cc-a3cb16a3b538" Level="4" /> <!-- Microsoft-Windows-Winlogon -->
+    <EventProvider Id="EP_Microsoft-Windows-Subsys-Csr" Name="e8316a2d-0d94-4f52-85dd-1e15b66c5891" Level="4" /> <!-- Microsoft-Windows-Subsys-Csr -->
+
+    <EventProvider Id="EP_Microsoft-Windows-Services" Name="0063715b-eeda-4007-9429-ad526f62696e" Level="4"> <!-- Microsoft-Windows-Services -->
+      <Keywords>
+        <Keyword Value="0x00010000" />
+      </Keywords>
+    </EventProvider>
+
+    <EventProvider Id="EP_Microsoft-Windows-Winsrv" Name="9d55b53d-449b-4824-a637-24f9d69aa02f" Level="4"> <!-- Microsoft-Windows-Winsrv -->
+      <Keywords>
+        <Keyword Value="0x00000100" />
+      </Keywords>
+    </EventProvider>
+
+    <EventProvider Id="EP_Microsoft-Windows-Wininit" Name="206f6dea-d3c5-4d10-bc72-989f03c8b84b" Level="4"> <!-- Microsoft-Windows-Wininit -->
+      <Keywords>
+        <Keyword Value="0x00010000" />
+      </Keywords>
+    </EventProvider>
+
+    <EventProvider Id="EP_Microsoft-Windows-Winlogon" Name="dbe9b383-7cf3-4331-91cc-a3cb16a3b538" Level="4"> <!-- Microsoft-Windows-Winlogon -->
+      <Keywords>
+        <Keyword Value="0x00030000" />
+      </Keywords>
+    </EventProvider>
+
+    <EventProvider Id="EP_Microsoft-Windows-Kernel-Power" Name="331c3b3a-2005-44c2-ac5e-77220c37d6b4" Level="4"> <!-- Microsoft-Windows-Kernel-Power -->
+      <Keywords>
+        <Keyword Value="0x00000008" />
+      </Keywords>
+    </EventProvider>
+
+    <EventProvider Id="EP_Microsoft-Windows-Shell-AuthUI" Name="63d2bb1d-e39a-41b8-9a3d-52dd06677588" Level="4" /> <!-- Microsoft-Windows-Shell-AuthUI -->
 
 <!--
     Profile Declarations
@@ -340,6 +372,35 @@
 
     <Profile Name="WindowsStart" Description="Standalone Windows Providers for OS Startup"
      DetailLevel="Light" LoggingMode="Memory" Base="WindowsStart.Light.File" Id="WindowsStart.Light.Memory" />
+
+    <!-- Windows Shut-down (may stand alone) -->
+
+    <Profile Name="WindowsShutdown" Description="Standalone Windows Providers for OS Shutdown"
+     DetailLevel="Light" LoggingMode="File" Base="Basic.Light.File" Id="WindowsShutdown.Light.File">
+      <Collectors Operation="Add">
+
+        <!-- Stand-alone profile: bare minimum -->
+        <SystemCollectorId Value="SC_4-MB">
+          <SystemProviderId Value="SP_Base" />
+        </SystemCollectorId>
+
+        <EventCollectorId Value="EC_16-MB">
+          <EventProviders Operation="Add">
+            <EventProviderId Value="EP_Microsoft-Windows-Wininit" />
+            <EventProviderId Value="EP_Microsoft-Windows-Winlogon" />
+            <EventProviderId Value="EP_Microsoft-Windows-Services" />
+            <EventProviderId Value="EP_Microsoft-Windows-Winsrv" />
+            <EventProviderId Value="EP_Microsoft-Windows-Subsys-Csr" />
+            <EventProviderId Value="EP_Microsoft-Windows-Kernel-Power" />
+            <EventProviderId Value="EP_Microsoft-Windows-Shell-AuthUI" />
+          </EventProviders>
+        </EventCollectorId>
+
+      </Collectors>
+    </Profile>
+
+    <Profile Name="WindowsShutdown" Description="Standalone Windows Providers for OS Shutdown"
+     DetailLevel="Light" LoggingMode="Memory" Base="WindowsShutdown.Light.File" Id="WindowsShutdown.Light.Memory" />
 
     <!-- Tutti Frutti (may stand-alone) -->
 


### PR DESCRIPTION
**Include.ps1**
- Introduce environment variable WPT_Mode for more esoteric behaviors.
   WPT_Mode=Shutdown : Enable tracing Windows Shutdown: `WPR -start <profile> -shutdown`
- Fix GetRunningTraceProviders: Better detect "WPR is not recording" -- which also fixes CLR/C# trace detection.
- Improve: Trace* Status -verbose : better display active providers.

**WPRP\WindowsProviders\*.wprp**
- Add WindowsShutdown profile for FullBoot.Shutdown.wpaProfile and the shutdown regions-of-interest chart.
- See: https://github.com/microsoft/MSO-Scripts/wiki/Analyze-Windows-Boot#shutdown

**Include.WPA.ps1**
- Clarify 3 comments
