### PR TITLE
Adding basic workflow for MSO-Scripts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,5 @@
 name: test-release-action
+
 on:
   workflow_dispatch:
     inputs:
@@ -6,6 +7,7 @@ on:
         description: 'Release version'
         required: true
         type: string
+
 jobs:
   create-release:
     runs-on: windows-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,23 @@
+name: test-release-action
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release version'
+        required: true
+        type: string
+jobs:
+  create-release:
+    runs-on: windows-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Create artifacts directory
+        run: mkdir bin
+
+      - name: Copy scripts
+        run: xcopy /s src bin
+
+      - name: Publish release
+        run: gh release create v${{ inputs.version }} --title "Release v${{ inputs.version }}" bin

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,11 +15,16 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v4
 
-      - name: Create artifacts directory
-        run: mkdir bin
+      - name: Create artifacts directory
+        run: mkdir bin
 
-      - name: Copy scripts
-        run: xcopy /s src bin
+      - name: Copy scripts
+        run: xcopy /e /i src bin
+
+      - name: Authenticate GitHub CLI
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | gh auth login --with-token
 
       - name: Publish release
-        run: gh release create v${{ inputs.version }} --title "Release v${{ inputs.version }}" bin
+        run: gh release create v${{ inputs.version }} --title "Release v${{ inputs.version }}" bin --notes "Manual release"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
I'm going to play with GitHub workflows.
This mechanism allows to build and release GitHub projects. I think it would be better to go this way to replace downloading the whole project.
To test this mechanism, I create a simple workflow triggered manually.
Now it just copies files from project to a dedicated directory and publishes this directory as release of the project.
If it works good, we can add more building steps later.