### PR TITLE
Instrument WPA Launch, Query Plug-ins, Improve TraceNetwork

### DIFF
--- a/src/TraceNetwork.ps1
+++ b/src/TraceNetwork.ps1
@@ -171,10 +171,13 @@ $script:PSScriptParams = $script:PSBoundParameters # volatile
 		$Command = "$script:ScriptRootPath\BETA\$($script:MyInvocation.MyCommand)"
 		if (Test-Path -PathType Leaf $Command -ErrorAction:SilentlyContinue)
 		{
-			Write-Info "For easier analysis, please try the BETA version:"
-			$Command = "BETA\$(GetScriptCommand) View"
-			if ($FastSym) { $Command += " -FastSym" }
-			Write-Info $Command
+			if ((CheckOSVersion '10.0.0') -and (GetFileVersion (GetWptExePath "WPA.exe" -Silent) -ge '11.0.7'))
+			{
+				Write-Info "For easier analysis, please try the BETA version:"
+				$Command = "BETA\$(GetScriptCommand) View"
+				if ($FastSym) { $Command += " -FastSym" }
+				Write-Info $Command
+			}
 		}
 	}
 

--- a/src/WPRP/Network.15002.wprp
+++ b/src/WPRP/Network.15002.wprp
@@ -77,14 +77,14 @@
     <!-- TCP-IP -->
 
     <EventProvider Id="EP_Microsoft-Windows-TCPIP" Name="2f07e2ee-15db-40f1-90ef-9d7ba282188a" NonPagedMemory="true" Level="4">
-      <Keywords Operation="Add">
+      <CaptureStateOnStart Timeout="30">
         <Keyword Value="0x0000001300000080" />
-      </Keywords>
+      </CaptureStateOnStart>
     </EventProvider>
     <EventProvider Id="EP_Filtered_Microsoft-Windows-TCPIP" Name="2f07e2ee-15db-40f1-90ef-9d7ba282188a" NonPagedMemory="true" Level="4">
-      <Keywords Operation="Add">
+      <CaptureStateOnStart Timeout="30">
         <Keyword Value="0x0000001300000080" />
-      </Keywords>
+      </CaptureStateOnStart>
       <!-- Include only events required by NetBlame, WPA annotations, and related. -->
       <EventFilters FilterIn="true">
         <EventId Value="1002" /> <!-- TcpRequestConnect -->


### PR DESCRIPTION
* Instrument and "watch" WPA launch.
* Detect when WPA fails to launch (due to bad params or plug-in names).
* Query and remember available plug-ins (for BETA\TraceNetwork).
* Better handle WPA/WPR wrapper scripts: WPA.bat, WPR.cmd, etc.
* Other minor enhancements.

INCLUDE.ps1
-	Instrument InvokeExe/WPR
-	Include %WPT_PATH%\WPA.bat, etc.
-	Better handle potential errors in LaunchViewer

INCLUDE.WPA.ps1
-	WaitForProcessResponsive
-	Instrument LaunchViewerCommand
-	Better handle WPA.bat/.cmd

BETA\TraceNetwork.ps1
-	Detect when WPA failed to launch, and query its plug-in list.

TraceNetwork.ps1
-	Recommend BETA\TraceNetwork only when it will work.

WPRP\Network.15002.wprp
-	More extensive rundown of the TCP/IP provider: existing TCBs (Transfer Control Blocks)
