### PR TITLE
Target specific processes for symbol resolution and ThreadPool stitching

### DIFF
--- a/src/NetBlame/Providers/Thread.cs
+++ b/src/NetBlame/Providers/Thread.cs
@@ -367,7 +367,7 @@ namespace NetBlameCustomDataSource.Thread
 		public static readonly Guid guid = new Guid("{3d6fa8d1-fe05-11d0-9dda-00c04fd7ba7c}"); // Thread
 
 
-		public void Dispatch(in THREAD_EVENT evt)
+		public void Dispatch(in THREAD_EVENT evt, bool fTarget)
 		{
 			ThreadItem tItem;
 
@@ -385,7 +385,8 @@ namespace NetBlameCustomDataSource.Thread
 
 				tItem = AddThread(in evt);
 
-				if (this.IsInternalAdHocThread(in tItem))
+				// Only thread together the stacks if this process has network stalkwalks of interest.
+				if (fTarget && this.IsInternalAdHocThread(in tItem))
 				{
 					// Who created this thread? (It wasn't an external process.)
 					// We may discard (Unlink) this info later if this is determined to be a Thread/Task Pool thread.

--- a/src/NetBlame/Providers/WinINet.cs
+++ b/src/NetBlame/Providers/WinINet.cs
@@ -415,7 +415,7 @@ namespace NetBlameCustomDataSource.WinINet
 
 		public static readonly Guid guid = new Guid("{43d1a55c-76d6-4f7e-995c-64c711e5cafe}"); // Microsoft-Windows-WinINet
 
-		enum WINET
+		public enum WINET
 		{
 			RequestCreatedA = 104,
 			HandleClosed = 105,

--- a/src/NetBlame/Providers/WinsockAFD.cs
+++ b/src/NetBlame/Providers/WinsockAFD.cs
@@ -63,7 +63,7 @@ namespace NetBlameCustomDataSource.WinsockAFD
 	{
 	//	SocketType field (AFD.Create record when EnterExit==0):
 		SOCK_NULL      = 0,
-		SOCK_STREAM	   = 1, // stream socket   (TCP) (common)
+		SOCK_STREAM    = 1, // stream socket   (TCP) (common)
 		SOCK_DGRAM     = 2, // datagram socket (UDP) (common)
 		SOCK_RAW       = 3, // raw-protocol interface
 		SOCK_RDM       = 4, // reliably-delivered message
@@ -451,7 +451,7 @@ namespace NetBlameCustomDataSource.WinsockAFD
 
 		public static readonly Guid guid = new Guid("{e53c6823-7bb8-44bb-90dc-3f86090d48a6}"); // Microsoft-Windows-WinSock-AFD
 
-		enum AFD
+		public enum AFD
 		{
 			Create = 1000,
 			Close = 1001,


### PR DESCRIPTION
NetBlame optimizes loading/parsing the ETL by more specifically choosing a list of Process IDs.

Rather than choosing the PIDs based on which processes have certain network providers (WinSock, WinINet, WebIO), it now chooses them based on specific events emitted by those providers.

A common pattern is to have lots of WinSock.Create/Close pairs.  Event though the Create event comes with a stackwalk, it will get ignored unless certain other WinSock events are also present.  This change understands that case.

For symbol resolution, the listed PIDs are turned into process names and used to filter the NetBlame-specific symbol resolution.
For stitching together threadpool stacks, threadpool-related events from processes which are NOT on the PID list will get filtered out.

In one test case, this PID-list-building prescan took 16 milliseconds to execute, but removed many minutes from the ETL load time because it completely filtered out a threadpool storm which included only the inert WinSock.Create/Close pairs.

Resolves #29