### PR TITLE
BETA\GetSymbols.bat: Don't require a full path for the ETL file.

### DIFF
--- a/src/BETA/GetSymbols.bat
+++ b/src/BETA/GetSymbols.bat
@@ -16,7 +16,7 @@ if [%1]==[-?] goto :Usage
 if [%1]==[/?] goto :Usage
 if /i not [%~x1]==[.etl] goto :Usage
 
-set _ETL="%~1"
+set _ETL="%~dpnx1"
 if not exist %_ETL% echo Does not exist: %_ETL% & goto :Usage
 
 rem Default symbol resolution paths.


### PR DESCRIPTION
GetSymbols.bat takes an ETL file reference, which it confirms the existence.
Then it does: `PushD c:\Symbols`, which makes any relative path invalid.
The fix is to get the full path from the start:
`set _ETL=%~dpnx1`

_I have no idea how this one file in this one commit in this one branch somehow picked up the changes in NetBlame/Auxiliary/NetUtil.cs yet again!_