### PR TITLE
Create a dedicated release script and remove excessive files

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,22 +27,11 @@ jobs:
           dotnet build  src\NetBlame\NetBlameAddIn.sln --configuration Release -p:Version=${{ inputs.version }}
         shell: cmd
 
-      - name: Create artifacts directory
-        run: mkdir bin\MSO-Scripts
-
-      - name: Create archive with all scripts
+      - name: Create ZIP archive with all scripts and binaries
         shell: pwsh
-        run: |
-          Get-ChildItem -Path "src" -File | Copy-Item -Destination "bin\MSO-Scripts"
-          Copy-Item -Path "src\BETA" -Destination "bin\MSO-Scripts\BETA" -Recurse
-          Copy-Item -Path "src\NetBlame\bin\Release\net8.0\*" -Destination "bin\MSO-Scripts\BETA\ADDIN" -Recurse
-          Copy-Item -Path "src\OETW" -Destination "bin\MSO-Scripts\OETW" -Recurse
-          Copy-Item -Path "src\PreWin10" -Destination "bin\MSO-Scripts\PreWin10" -Recurse
-          Copy-Item -Path "src\WPAP" -Destination "bin\MSO-Scripts\WPAP" -Recurse
-          Copy-Item -Path "src\WPRP" -Destination "bin\MSO-Scripts\WPRP" -Recurse
-          Compress-Archive -Path "bin\MSO-Scripts" -DestinationPath "bin\MSO-Scripts-${{ inputs.version }}.zip"
+        run: make\CreateRelease.ps1 -NetBlameBuild "src\NetBlame\bin\Release\net8.0" -WorkingDir bin -OutputZip "bin\MSO-Scripts-${{ inputs.version }}.zip"
 
       - name: Publish release
-        run: gh release create v${{ inputs.version }} --title "Release v${{ inputs.version }}" "bin\MSO-Scripts-${{ inputs.version }}.zip" --notes "Manual release"
+        run: gh release create version_${{ inputs.version }} --title "Release ${{ inputs.version }}" "bin\MSO-Scripts-${{ inputs.version }}.zip" --notes "Manual release"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/make/CreateRelease.ps1
+++ b/make/CreateRelease.ps1
@@ -1,0 +1,40 @@
+Param 
+(
+    [string]$NetBlameBuild,
+    [string]$WorkingDir,
+    [string]$OutputZip
+)
+
+$WorkingDir = "$WorkingDir\MSO-Scripts"
+
+# Create working directory to copy artifacts
+New-Item -ItemType Directory -Path $WorkingDir
+
+# Copy all main scripts 
+Get-ChildItem -Path "src" -File | Copy-Item -Destination $WorkingDir
+
+# Copy BETA scripts 
+Copy-Item -Path "src\BETA" -Destination "$WorkingDir\BETA" -Recurse
+
+# Copy ADDIN binaries from NetBlame build
+$AddinDir = "$WorkingDir\BETA\ADDIN"
+Get-ChildItem -Path $NetBlameBuild -File | Copy-Item -Destination $AddinDir
+
+$Platforms = 'arm64', 'x64'
+$Binaries = 'msdia140.dll', 'perfcore.dll', 'perf_nt.dll', 'perf_dynamic.dll', 'symcache.dll', 'symsrv.dll' 
+
+ForEach ($platform in $Platforms) {
+   $PlatformDir = "$AddinDir\$platform"
+   New-Item -ItemType Directory -Path "$PlatformDir\wpt"
+   ForEach ($binary in $Binaries) {
+      Copy-Item -Path "$NetBlameBuild\$platform\wpt\$binary" -Destination "$PlatformDir\wpt"
+   }
+}
+
+# Copy remaing data
+Copy-Item -Path "src\OETW" -Destination "$WorkingDir\OETW" -Recurse
+Copy-Item -Path "src\PreWin10" -Destination "$WorkingDir\PreWin10" -Recurse
+Copy-Item -Path "src\WPAP" -Destination "$WorkingDir\WPAP" -Recurse
+Copy-Item -Path "src\WPRP" -Destination "$WorkingDir\WPRP" -Recurse
+
+Compress-Archive -Path $WorkingDir -DestinationPath $OutputZip


### PR DESCRIPTION
To control packaging more convenient, I created a separate release script **make\CreateRelease.ps1**. It can be locally used to create a ZIP archive with all scripts and binaries.

According to notes in the issue #34, I remove excessive files from release package:
- I drop **amd64**, **arm**, and **x86** directories from NetBlame build
- I copy all binaries from **net8.0** directory. It looks like _NuGet.Versioning.dll_ is dependency for _Microsoft.Performance.SDK.dll_, so I keep it around
- I copy the following set of binaries 'msdia140.dll', 'perfcore.dll', 'perf_nt.dll', 'perf_dynamic.dll', 'symcache.dll', 'symsrv.dll' from **wpt** directory for each platform