### PR TITLE
Improve geolocation and other descriptions of the IPAddress

### DIFF
--- a/src/NetBlame/Providers/WinsockAFD.cs
+++ b/src/NetBlame/Providers/WinsockAFD.cs
@@ -42,6 +42,8 @@ namespace NetBlameCustomDataSource.WinsockAFD
 		UDP           = 17, // (datagram socket)
 		IDP           = 22,
 		RDP           = 27,
+		HyperV        = 34, // pseudo: AF_HYPERV
+		VSock         = 40, // pseudo: AF_VSOCK
 		IPV6          = 41, // IPv6 header
 		ROUTING       = 43, // IPv6 Routing header
 		FRAGMENT      = 44, // IPv6 fragmentation header
@@ -502,6 +504,10 @@ namespace NetBlameCustomDataSource.WinsockAFD
 					// Find counterexamples (not critical)
 					AssertImportant((cxn.ipProtocol==IPPROTO.TCP || cxn.ipProtocol==IPPROTO.ICMP) == (cxn.socktype==SOCKTYPE.SOCK_STREAM));
 					AssertImportant((cxn.ipProtocol==IPPROTO.UDP) == (cxn.socktype==SOCKTYPE.SOCK_DGRAM));
+
+					var family = (System.Net.Sockets.AddressFamily)evt.GetUInt32("AddressFamily");
+					if (family == AF_HYPERV) cxn.ipProtocol = IPPROTO.HyperV;
+					else if (family == AF_VSOCK) cxn.ipProtocol = IPPROTO.VSock;
 
 					cxn.xlink.GetLink(evt.ThreadId, cxn.timeCreate, in allTables.threadTable);
 					this.Add(cxn);


### PR DESCRIPTION
### GeoLocation ###
Make GeoLocation more accurate and efficient:
There are large IP address ranges reserved for private networks and therefore have no geo-location.
These addresses show up a fair amount in network traces. _The GeoLocation service simply returns 404._
Instead, detect and short-circuit those addresses. Simply return: "Local/Private Network"

### Linux on Windows ###
Linux on Windows [communicates with a socket](https://github.com/search?q=repo%3Amicrosoft%2FWSL2-Linux-Kernel+AF_HYPERV) using AF_HYPERV (34) and size = 16.
Copy the 12 bytes into an IPv6 address and set the port=34 as a tag.

Also, extend the translation from port numbers to service names (ie. :443 => HTTPS, etc.).