### PR TITLE
Handle Mark of the Web on downloaded files.

### DIFF
--- a/src/BETA/Generate-PmuRegFile.bat
+++ b/src/BETA/Generate-PmuRegFile.bat
@@ -5,6 +5,15 @@ REM The powershell script has the same path and base name as this batch script.
 set _PATH="%~dpn0.ps1"
 set _ARGS=%*
 
+REM Detect, warn, and remove Mark of the Web.
+(more < "%~dpn0.ps1:Zone.Identifier") >nul 2>nul && (
+	echo Unblocking downloaded PowerShell script: %~n0.ps1
+	echo https://github.com/microsoft/MSO-Scripts/wiki/Frequently-Asked-Questions#policy
+	echo:>"%~dpn0.ps1:Zone.Identifier"
+	powershell unblock-file '%~dpn0.ps1' 2>nul
+	echo:
+)
+
 REM Escape spaces and quotes for use with: -command
 set _CMD=-command %_PATH: =` %
 if defined _ARGS set _CMD=%_CMD% %_ARGS:"='%

--- a/src/BETA/TraceEdgeChrome.bat
+++ b/src/BETA/TraceEdgeChrome.bat
@@ -5,6 +5,16 @@ REM The powershell script has the same path and base name as this batch script.
 set _PATH="%~dpn0.ps1"
 set _ARGS=%*
 
+REM Detect, warn, and remove Mark of the Web.
+set TraceThis=%~n0.ps1
+set Include=..\INCLUDE*.ps1
+(more < "%~dp0%TraceThis%:Zone.Identifier") >nul 2>nul && (
+	echo Unblocking downloaded PowerShell scripts: %TraceThis%, %Include%
+	echo https://github.com/microsoft/MSO-Scripts/wiki/Frequently-Asked-Questions#policy
+	for %%f in ("%~dp0%TraceThis%","%~dp0%Include%") do echo %%~nxf & echo:>"%%~f:Zone.Identifier"
+	echo:
+)
+
 REM Escape spaces and quotes for use with: -command
 set _CMD=-command %_PATH: =` %
 if defined _ARGS set _CMD=%_CMD% %_ARGS:"='%

--- a/src/BETA/TraceNetwork.bat
+++ b/src/BETA/TraceNetwork.bat
@@ -5,6 +5,16 @@ REM The powershell script has the same path and base name as this batch script.
 set _PATH="%~dpn0.ps1"
 set _ARGS=%*
 
+REM Detect, warn, and remove Mark of the Web.
+set TraceThis=%~n0.ps1
+set Include=..\INCLUDE*.ps1
+(more < "%~dp0%TraceThis%:Zone.Identifier") >nul 2>nul && (
+	echo Unblocking downloaded PowerShell scripts: %TraceThis%, %Include%
+	echo https://github.com/microsoft/MSO-Scripts/wiki/Frequently-Asked-Questions#policy
+	for %%f in ("%~dp0%TraceThis%","%~dp0%Include%") do echo %%~nxf & echo:>"%%~f:Zone.Identifier"
+	echo:
+)
+
 REM Escape spaces and quotes for use with: -command
 set _CMD=-command %_PATH: =` %
 if defined _ARGS set _CMD=%_CMD% %_ARGS:"='%

--- a/src/BETA/TracePMC.bat
+++ b/src/BETA/TracePMC.bat
@@ -5,6 +5,16 @@ REM The powershell script has the same path and base name as this batch script.
 set _PATH="%~dpn0.ps1"
 set _ARGS=%*
 
+REM Detect, warn, and remove Mark of the Web.
+set TraceThis=%~n0.ps1
+set Include=..\INCLUDE*.ps1
+(more < "%~dp0%TraceThis%:Zone.Identifier") >nul 2>nul && (
+	echo Unblocking downloaded PowerShell scripts: %TraceThis%, %Include%
+	echo https://github.com/microsoft/MSO-Scripts/wiki/Frequently-Asked-Questions#policy
+	for %%f in ("%~dp0%TraceThis%","%~dp0%Include%") do echo %%~nxf & echo:>"%%~f:Zone.Identifier"
+	echo:
+)
+
 REM Escape spaces and quotes for use with: -command
 set _CMD=-command %_PATH: =` %
 if defined _ARGS set _CMD=%_CMD% %_ARGS:"='%

--- a/src/INCLUDE.ps1
+++ b/src/INCLUDE.ps1
@@ -3472,11 +3472,31 @@ function CheckLanguageMode
 
 
 <#
+	If the given file is blocked with Mark of the Web, then unblock all related .ps1 files.
+#>
+function CheckMarkOfTheWeb
+{
+Param (
+	$Path
+)
+	if ($Path -and (Get-Item -Path $Path -Stream 'Zone.Identifier' -ErrorAction:SilentlyContinue))
+	{
+		Write-Warn 'Unblocking all downloaded PowerShell scripts in this folder: *.ps1'
+		$Path = Split-Path -Parent -Path $Path
+		Get-ChildItem -Path $Path -Recurse -Filter '*.ps1' | Unblock-File -ErrorAction:SilentlyContinue -Verbose:(DoVerbose)
+		Write-Warn
+	}
+}
+
+
+<#
 	These actions must occur immediately upon load.
 #>
 # Main
 
 CheckLanguageMode
+
+if ($Host.Version.Major -gt 2) { CheckMarkOfTheWeb $MyInvocation.MyCommand.Path }
 
 # Native enum doesn't exist until PS v5.0
 Add-Type -TypeDefinition @"

--- a/src/ResetWPA.bat
+++ b/src/ResetWPA.bat
@@ -5,6 +5,15 @@ REM The powershell script has the same path and base name as this batch script.
 set _PATH="%~dpn0.ps1"
 set _ARGS=%*
 
+REM Detect, warn, and remove Mark of the Web.
+(more < "%~dpn0.ps1:Zone.Identifier") >nul 2>nul && (
+	echo Unblocking downloaded PowerShell script: %~n0.ps1
+	echo https://github.com/microsoft/MSO-Scripts/wiki/Frequently-Asked-Questions#policy
+	echo:>"%~dpn0.ps1:Zone.Identifier"
+	powershell unblock-file '%~dpn0.ps1' 2>nul
+	echo:
+)
+
 REM Escape spaces and quotes for use with: -command
 set _CMD=-command %_PATH: =` %
 if defined _ARGS set _CMD=%_CMD% %_ARGS:"='%

--- a/src/SymbolScan.bat
+++ b/src/SymbolScan.bat
@@ -5,6 +5,15 @@ REM The powershell script has the same path and base name as this batch script.
 set _PATH="%~dpn0.ps1"
 set _ARGS=%*
 
+REM Detect, warn, and remove Mark of the Web.
+(more < "%~dpn0.ps1:Zone.Identifier") >nul 2>nul && (
+	echo Unblocking downloaded PowerShell script: %~n0.ps1
+	echo https://github.com/microsoft/MSO-Scripts/wiki/Frequently-Asked-Questions#policy
+	echo:>"%~dpn0.ps1:Zone.Identifier"
+	powershell unblock-file '%~dpn0.ps1' 2>nul
+	echo:
+)
+
 REM Escape spaces and quotes for use with: -command
 set _CMD=-command %_PATH: =` %
 if defined _ARGS set _CMD=%_CMD% %_ARGS:"='%

--- a/src/TraceCPU.bat
+++ b/src/TraceCPU.bat
@@ -5,6 +5,16 @@ REM The powershell script has the same path and base name as this batch script.
 set _PATH="%~dpn0.ps1"
 set _ARGS=%*
 
+REM Detect, warn, and remove Mark of the Web.
+set TraceThis=%~n0.ps1
+set Include=INCLUDE*.ps1
+(more < "%~dp0%TraceThis%:Zone.Identifier") >nul 2>nul && (
+	echo Unblocking downloaded PowerShell scripts: %TraceThis%, %Include%
+	echo https://github.com/microsoft/MSO-Scripts/wiki/Frequently-Asked-Questions#policy
+	for %%f in ("%~dp0%TraceThis%","%~dp0%Include%") do echo %%~nxf & echo:>"%%~f:Zone.Identifier"
+	echo:
+)
+
 REM Escape spaces and quotes for use with: -command
 set _CMD=-command %_PATH: =` %
 if defined _ARGS set _CMD=%_CMD% %_ARGS:"='%

--- a/src/TraceFileDiskIO.bat
+++ b/src/TraceFileDiskIO.bat
@@ -5,6 +5,16 @@ REM The powershell script has the same path and base name as this batch script.
 set _PATH="%~dpn0.ps1"
 set _ARGS=%*
 
+REM Detect, warn, and remove Mark of the Web.
+set TraceThis=%~n0.ps1
+set Include=INCLUDE*.ps1
+(more < "%~dp0%TraceThis%:Zone.Identifier") >nul 2>nul && (
+	echo Unblocking downloaded PowerShell scripts: %TraceThis%, %Include%
+	echo https://github.com/microsoft/MSO-Scripts/wiki/Frequently-Asked-Questions#policy
+	for %%f in ("%~dp0%TraceThis%","%~dp0%Include%") do echo %%~nxf & echo:>"%%~f:Zone.Identifier"
+	echo:
+)
+
 REM Escape spaces and quotes for use with: -command
 set _CMD=-command %_PATH: =` %
 if defined _ARGS set _CMD=%_CMD% %_ARGS:"='%

--- a/src/TraceHandles.bat
+++ b/src/TraceHandles.bat
@@ -5,6 +5,16 @@ REM The powershell script has the same path and base name as this batch script.
 set _PATH="%~dpn0.ps1"
 set _ARGS=%*
 
+REM Detect, warn, and remove Mark of the Web.
+set TraceThis=%~n0.ps1
+set Include=INCLUDE*.ps1
+(more < "%~dp0%TraceThis%:Zone.Identifier") >nul 2>nul && (
+	echo Unblocking downloaded PowerShell scripts: %TraceThis%, %Include%
+	echo https://github.com/microsoft/MSO-Scripts/wiki/Frequently-Asked-Questions#policy
+	for %%f in ("%~dp0%TraceThis%","%~dp0%Include%") do echo %%~nxf & echo:>"%%~f:Zone.Identifier"
+	echo:
+)
+
 REM Escape spaces and quotes for use with: -command
 set _CMD=-command %_PATH: =` %
 if defined _ARGS set _CMD=%_CMD% %_ARGS:"='%

--- a/src/TraceHeap.bat
+++ b/src/TraceHeap.bat
@@ -5,6 +5,16 @@ REM The powershell script has the same path and base name as this batch script.
 set _PATH="%~dpn0.ps1"
 set _ARGS=%*
 
+REM Detect, warn, and remove Mark of the Web.
+set TraceThis=%~n0.ps1
+set Include=INCLUDE*.ps1
+(more < "%~dp0%TraceThis%:Zone.Identifier") >nul 2>nul && (
+	echo Unblocking downloaded PowerShell scripts: %TraceThis%, %Include%
+	echo https://github.com/microsoft/MSO-Scripts/wiki/Frequently-Asked-Questions#policy
+	for %%f in ("%~dp0%TraceThis%","%~dp0%Include%") do echo %%~nxf & echo:>"%%~f:Zone.Identifier"
+	echo:
+)
+
 REM Escape spaces and quotes for use with: -command
 set _CMD=-command %_PATH: =` %
 if defined _ARGS set _CMD=%_CMD% %_ARGS:"='%

--- a/src/TraceHeapEx.bat
+++ b/src/TraceHeapEx.bat
@@ -5,6 +5,16 @@ REM The powershell script has the same path and base name as this batch script.
 set _PATH="%~dpn0.ps1"
 set _ARGS=%*
 
+REM Detect, warn, and remove Mark of the Web.
+set TraceThis=%~n0.ps1
+set Include=INCLUDE*.ps1
+(more < "%~dp0%TraceThis%:Zone.Identifier") >nul 2>nul && (
+	echo Unblocking downloaded PowerShell scripts: %TraceThis%, %Include%
+	echo https://github.com/microsoft/MSO-Scripts/wiki/Frequently-Asked-Questions#policy
+	for %%f in ("%~dp0%TraceThis%","%~dp0%Include%") do echo %%~nxf & echo:>"%%~f:Zone.Identifier"
+	echo:
+)
+
 REM Escape spaces and quotes for use with: -command
 set _CMD=-command %_PATH: =` %
 if defined _ARGS set _CMD=%_CMD% %_ARGS:"='%

--- a/src/TraceMemory.bat
+++ b/src/TraceMemory.bat
@@ -5,6 +5,16 @@ REM The powershell script has the same path and base name as this batch script.
 set _PATH="%~dpn0.ps1"
 set _ARGS=%*
 
+REM Detect, warn, and remove Mark of the Web.
+set TraceThis=%~n0.ps1
+set Include=INCLUDE*.ps1
+(more < "%~dp0%TraceThis%:Zone.Identifier") >nul 2>nul && (
+	echo Unblocking downloaded PowerShell scripts: %TraceThis%, %Include%
+	echo https://github.com/microsoft/MSO-Scripts/wiki/Frequently-Asked-Questions#policy
+	for %%f in ("%~dp0%TraceThis%","%~dp0%Include%") do echo %%~nxf & echo:>"%%~f:Zone.Identifier"
+	echo:
+)
+
 REM Escape spaces and quotes for use with: -command
 set _CMD=-command %_PATH: =` %
 if defined _ARGS set _CMD=%_CMD% %_ARGS:"='%

--- a/src/TraceMondo.bat
+++ b/src/TraceMondo.bat
@@ -5,6 +5,16 @@ REM The powershell script has the same path and base name as this batch script.
 set _PATH="%~dpn0.ps1"
 set _ARGS=%*
 
+REM Detect, warn, and remove Mark of the Web.
+set TraceThis=%~n0.ps1
+set Include=INCLUDE*.ps1
+(more < "%~dp0%TraceThis%:Zone.Identifier") >nul 2>nul && (
+	echo Unblocking downloaded PowerShell scripts: %TraceThis%, %Include%
+	echo https://github.com/microsoft/MSO-Scripts/wiki/Frequently-Asked-Questions#policy
+	for %%f in ("%~dp0%TraceThis%","%~dp0%Include%") do echo %%~nxf & echo:>"%%~f:Zone.Identifier"
+	echo:
+)
+
 REM Escape spaces and quotes for use with: -command
 set _CMD=-command %_PATH: =` %
 if defined _ARGS set _CMD=%_CMD% %_ARGS:"='%

--- a/src/TraceNetwork.bat
+++ b/src/TraceNetwork.bat
@@ -5,6 +5,16 @@ REM The powershell script has the same path and base name as this batch script.
 set _PATH="%~dpn0.ps1"
 set _ARGS=%*
 
+REM Detect, warn, and remove Mark of the Web.
+set TraceThis=%~n0.ps1
+set Include=INCLUDE*.ps1
+(more < "%~dp0%TraceThis%:Zone.Identifier") >nul 2>nul && (
+	echo Unblocking downloaded PowerShell scripts: %TraceThis%, %Include%
+	echo https://github.com/microsoft/MSO-Scripts/wiki/Frequently-Asked-Questions#policy
+	for %%f in ("%~dp0%TraceThis%","%~dp0%Include%") do echo %%~nxf & echo:>"%%~f:Zone.Identifier"
+	echo:
+)
+
 REM Escape spaces and quotes for use with: -command
 set _CMD=-command %_PATH: =` %
 if defined _ARGS set _CMD=%_CMD% %_ARGS:"='%

--- a/src/TraceOffice.bat
+++ b/src/TraceOffice.bat
@@ -5,6 +5,16 @@ REM The powershell script has the same path and base name as this batch script.
 set _PATH="%~dpn0.ps1"
 set _ARGS=%*
 
+REM Detect, warn, and remove Mark of the Web.
+set TraceThis=%~n0.ps1
+set Include=INCLUDE*.ps1
+(more < "%~dp0%TraceThis%:Zone.Identifier") >nul 2>nul && (
+	echo Unblocking downloaded PowerShell scripts: %TraceThis%, %Include%
+	echo https://github.com/microsoft/MSO-Scripts/wiki/Frequently-Asked-Questions#policy
+	for %%f in ("%~dp0%TraceThis%","%~dp0%Include%") do echo %%~nxf & echo:>"%%~f:Zone.Identifier"
+	echo:
+)
+
 REM Escape spaces and quotes for use with: -command
 set _CMD=-command %_PATH: =` %
 if defined _ARGS set _CMD=%_CMD% %_ARGS:"='%

--- a/src/TraceOutlook.bat
+++ b/src/TraceOutlook.bat
@@ -5,6 +5,16 @@ REM The powershell script has the same path and base name as this batch script.
 set _PATH="%~dpn0.ps1"
 set _ARGS=%*
 
+REM Detect, warn, and remove Mark of the Web.
+set TraceThis=%~n0.ps1
+set Include=INCLUDE*.ps1
+(more < "%~dp0%TraceThis%:Zone.Identifier") >nul 2>nul && (
+	echo Unblocking downloaded PowerShell scripts: %TraceThis%, %Include%
+	echo https://github.com/microsoft/MSO-Scripts/wiki/Frequently-Asked-Questions#policy
+	for %%f in ("%~dp0%TraceThis%","%~dp0%Include%") do echo %%~nxf & echo:>"%%~f:Zone.Identifier"
+	echo:
+)
+
 REM Escape spaces and quotes for use with: -command
 set _CMD=-command %_PATH: =` %
 if defined _ARGS set _CMD=%_CMD% %_ARGS:"='%

--- a/src/TraceRegistry.bat
+++ b/src/TraceRegistry.bat
@@ -5,6 +5,16 @@ REM The powershell script has the same path and base name as this batch script.
 set _PATH="%~dpn0.ps1"
 set _ARGS=%*
 
+REM Detect, warn, and remove Mark of the Web.
+set TraceThis=%~n0.ps1
+set Include=INCLUDE*.ps1
+(more < "%~dp0%TraceThis%:Zone.Identifier") >nul 2>nul && (
+	echo Unblocking downloaded PowerShell scripts: %TraceThis%, %Include%
+	echo https://github.com/microsoft/MSO-Scripts/wiki/Frequently-Asked-Questions#policy
+	for %%f in ("%~dp0%TraceThis%","%~dp0%Include%") do echo %%~nxf & echo:>"%%~f:Zone.Identifier"
+	echo:
+)
+
 REM Escape spaces and quotes for use with: -command
 set _CMD=-command %_PATH: =` %
 if defined _ARGS set _CMD=%_CMD% %_ARGS:"='%


### PR DESCRIPTION
#### The Short Story ####
Depending on how MSO-Scripts is downloaded and unzipped, the files may get the "Mark of the Web."
This causes PowerShell (depending on the execution policy) to either refuse to execute the script, or it requests approval for each script loaded: TraceCPU.ps1, INCLUDE.ps1, INCLUDE.WPA.ps1  (See Issue #39 for details.)

This pull request takes a two-pronged approach to neutralizing the Mark of the Web (MotW), based on the notion that PowerShell may be extra careful, but running the batch file wrapper will get the job done:
1. All of the batch files that launch a PowerShell script detect and neutralize the MotW on that script. If needed, they also neutralize MotW on: INCLUDE*.ps1 or: ..\INCLUDE*.ps1
2. When INCLUDE.ps1 loads, it detects MotW on itself (even if neutralized), and it runs [Unblock-File](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.utility/unblock-file) on *.ps1 on its own folder and sub-folders, removing all trace of MotW.

In both cases, a warning is emitted.

_Another option would be to avoid adding this bit of code to all *.bat files, and instead create a "fix-it" script that you run after downloading/unzipping.  However, that requires extra steps and documentation, and perhaps user frustration._

#### The Long Story ####
Windows implements MotW as a NTFS Alternate Stream named :Zone.Identifier , and containing specific text:
```
[ZoneTransfer]
ZoneId=3
```
Each batch script is able to detect this alternate stream and null it out, but not remove it completely (without invoking PowerShell).
```
REM Detect, warn, and remove Mark of the Web.
(more < "%~dpn0.ps1:Zone.Identifier") >nul 2>nul && (
	echo Unblocking downloaded PowerShell script: %~n0.ps1
	echo https://github.com/microsoft/MSO-Scripts/wiki/Frequently-Asked-Questions#policy
	echo:>"%~dpn0.ps1:Zone.Identifier"
	powershell unblock-file '%~dpn0.ps1' 2>nul
	echo:
)
```
OR:
```
REM Detect, warn, and remove Mark of the Web.
set TraceThis=%~n0.ps1
set Include=INCLUDE*.ps1 & REM or: ..\INCLUDE*.ps1
(more < "%~dp0%TraceThis%:Zone.Identifier") >nul 2>nul && (
	echo Unblocking downloaded PowerShell scripts: %TraceThis%, %Include%
	echo https://github.com/microsoft/MSO-Scripts/wiki/Frequently-Asked-Questions#policy
	for %%f in ("%~dp0%TraceThis%","%~dp0%Include%") do echo %%~nxf & echo:>"%%~f:Zone.Identifier"
	echo:
)
```
This executes when INCLUDE.ps1 loads:
```
if ($Path -and (Get-Item -Path $Path -Stream 'Zone.Identifier' -ErrorAction:SilentlyContinue))
{
	Write-Warn 'Unblocking all downloaded PowerShell scripts in this folder: *.ps1'
	$Path = Split-Path -Parent -Path $Path
	Get-ChildItem -Path $Path -Recurse -Filter '*.ps1' | Unblock-File -ErrorAction:SilentlyContinue -Verbose:(DoVerbose)
	Write-Warn
}
```