### PR TITLE
Update the GeoLocation free service to ip-api.com

### DIFF
--- a/src/BETA/ADDIN/ReadMe.txt
+++ b/src/BETA/ADDIN/ReadMe.txt
@@ -1,7 +1,6 @@
 Copyright (c) Microsoft Corporation. Licensed under the MIT License.
 
-This product includes GeoLite2 data created by MaxMind, available from
-  https://www.maxmind.com
+This component uses the free IP-GeoLocation API from ip-api at: https://ip-api.com
 
 This is the _only_ folder with binary executable code, consisting of WPA add-ins.
 It can be removed with only limited loss of functionality for the WPA viewer.

--- a/src/BETA/WPAP/Network.wpaProfile
+++ b/src/BETA/WPAP/Network.wpaProfile
@@ -34,7 +34,7 @@
                 <Column Guid="e6b391a8-d2c4-d459-02a2-3a8b6585703d" Name="URL" SortPriority="2" Width="386" IsVisible="true" HelpText="Full URL Path" />
                 <Column Guid="da5cd305-10bf-285c-61e2-493e6f232fb3" Name="IPAddr:Port" SortPriority="2" Width="170" IsVisible="true" HelpText="Remote IP Address &amp; Port" />
                 <Column Guid="ec53a8c4-f07b-aed5-d882-5072c89799be" Name="Status" SortPriority="0" Width="150" IsVisible="false" HelpText="Last non-zero status of the transaction" />
-                <Column Guid="6c2c4e61-8f05-ab1d-567a-d53851e77c3d" Name="GeoLocation" SortPriority="0" Width="180" IsVisible="false" HelpText="IP Geolocation by geoPlugin:&#xA; https://www.geoplugin.com/ &#xA;This product includes GeoLite data created by MaxMind,&#xA;available from: https://www.maxmind.com" />
+                <Column Guid="6c2c4e61-8f05-ab1d-567a-d53851e77c3d" Name="GeoLocation" SortPriority="0" Width="180" IsVisible="false" HelpText="IP Geolocation provided by ip-api:&#xA; https://ip-api.com" />
                 <Column Guid="e02d2ae0-3de9-d493-df2b-6b2d2813d302" Name="Duration" AggregationMode="Max" SortPriority="2" TextAlignment="Right" Width="96" CellFormat="mN" IsVisible="true" HelpText="Time from Open to Close (ms)">
                   <DurationInViewOptionsParameter TimeStampColumnGuid="c2a764ec-9a6c-eb16-8137-cf1b6b8b8bea" TimeStampType="Start" InViewEnabled="false" />
                 </Column>

--- a/src/NetBlame/README.md
+++ b/src/NetBlame/README.md
@@ -17,7 +17,7 @@ This add-in analyzes and summarizes network and thread pool ETW events:
 
 It is based on the [Microsoft Performance Toolkit SDK](https://github.com/microsoft/microsoft-performance-toolkit-sdk)
 
-This product includes GeoLite2 data created by MaxMind, available from https://www.maxmind.com
+This product includes GeoLocation data created by ip-api, available at https://ip-api.com
 
 # Build
 


### PR DESCRIPTION
Fixes #44 : GeoLocation: Need to change the service used to populate this column.

NetBlame has used the free IP GeoLocation XML service from GeoPlugin.com
However, it appears that there is no more free version of this service.

This change switches to the free IP GeoLocation JSON service from ip-api : https://ip-api.com
This free service allows 45 requests / minute.

* Change the GeoLocation class to process JSON via http://ip-api.com/json/
  - NetBlame/Auxiliary/GeoLocation.cs

* Change the attribution to refer to: ip-api.com
  - NetBlame/Auxiliary/GeoLocation.cs
  - NetBlame/README.md
  - BETA/ADDIN/ReadMe.txt
  - BETA/WPAP/Network.wpaProfile
